### PR TITLE
Update python.xml to support 2.7 format "{}"

### DIFF
--- a/src/syntax/data/python.xml
+++ b/src/syntax/data/python.xml
@@ -499,7 +499,7 @@
 				-->
 				<RegExpr attribute="String Substitution" String="%((\([a-zA-Z0-9_]+\))?[#0\- +]?([1-9][0-9]*|\*)?(\.([1-9][0-9]*|\*))?[hlL]?[crsdiouxXeEfFgG%]|prog|default)" context="#stay"/>
 				<!-- http://docs.python.org/2/library/string.html#format-string-syntax:
-				     replacement_field ::= "{" field_name ["!" conversion] [":" format_spec] "}"
+				     replacement_field ::= "{" [field_name] ["!" conversion] [":" format_spec] "}"
 				     field_name ::= (identifier | integer) ("." attribute_name | "[" element_index "]")*
 				     attribute_name ::= identifier
 				     element_index ::= integer | index_string
@@ -513,7 +513,7 @@
 				     precision ::= integer
 				     type ::= "b" | "c" | "d" | "e" | "E" | "f" | "F" | "g" | "G" | "n" | "o" | "s" | "x" | "X" | "%"
 				-->
-				<RegExpr attribute="String Substitution" String="\{([a-zA-Z0-9_]+|[0-9]+)(\.[a-zA-Z0-9_]+|\[[^ \]]+\])*(![rs])?(:([^}]?[&lt;&gt;=^])?[ +-]?#?0?[0-9]*(\.[0-9]+)?[bcdeEfFgGnosxX%]?)?\}" context="#stay"/>
+				<RegExpr attribute="String Substitution" String="\{(([a-zA-Z0-9_]+|[0-9]+)(\.[a-zA-Z0-9_]+|\[[^ \]]+\])*)?(![rs])?(:([^}]?[&lt;&gt;=^])?[ +-]?#?0?[0-9]*(\.[0-9]+)?[bcdeEfFgGnosxX%]?)?\}" context="#stay"/>
 				<Detect2Chars attribute="String Substitution" char="{" char1="{" context="#stay" />
 				<Detect2Chars attribute="String Substitution" char="}" char1="}" context="#stay" />
 			</context>


### PR DESCRIPTION
Now a string like "{} {}".format(0,1) will highlight the two "{}"
